### PR TITLE
Fix the `get_name` function

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -10,7 +10,7 @@ def get_extension(path):
 
 
 def get_name(path):
-    return path.name.rstrip(get_extension(path))
+    return path.name.split(".")[0]
 
 
 def read_dataframe(path):

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -1,2 +1,19 @@
-def test():
-    pass
+import pathlib
+
+import pytest
+
+from analysis import dataset_report
+
+
+@pytest.mark.parametrize(
+    "path,name",
+    [
+        (pathlib.Path("output/input.csv"), "input"),
+        (pathlib.Path("output/input.csv.gz"), "input"),
+        (pathlib.Path("output/input.feather"), "input"),
+        (pathlib.Path("output/input.dta"), "input"),
+        (pathlib.Path("output/input.dta.gz"), "input"),
+    ],
+)
+def test_get_name(path, name):
+    assert dataset_report.get_name(path) == name


### PR DESCRIPTION
Previously, the `get_name` function passed a file extension to the [`rstrip`](https://docs.python.org/3.8/library/stdtypes.html?highlight=rstrip#str.rstrip) method. However, this method doesn't strip *all* characters passed to it; it strips *any* characters passed to it.[^1] For example:

```py
>>> name = "input.feather"
>>> name.rstrip(".feather")
'inpu'
```

In this example, the file extension contains the letter "t", so `rstrip` strips the letter "t" from "input".

Another example:

```py
>>> name = "input.csv"
>>> name.rstrip(".csv")
'input'
```

In this example, the file extension has no letters in common with "input", so `rstrip` doesn't strip any letters from "input".

When run as a reusable action, dataset-report will generate a report for a feather file; however, this report probably won't be released, because _project.yaml_ will probably refer to _input.md_ rather than to _inpu.md_.

---

As an aside, the test in this PR is parameterized, which means it is run once, for each set of parameters. [pytest's syntax for parameterizing tests](https://docs.pytest.org/en/stable/how-to/parametrize.html) isn't elegant; but hopefully it's clear enough when the number/nature of the parameters is small/simple.

[^1]: The docs are clear about the all/any difference. And annoyingly, I read them before implementing the `get_name` function 🤯 However, I didn't test the function.