### PR TITLE
Fix `get_memory_usage`

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -58,6 +58,10 @@ def get_memory_usage(dataframe):
     memory_usage = dataframe.memory_usage(index=False)
     memory_usage = memory_usage / 1_000**2
     memory_usage.name = "Size (MB)"
+    # At this point, `dataframe.columns` is the same instance as `memory_usage.index`.
+    # Consequently, if we change the name of the latter, then we will also change the
+    # name of the former. This is undesirable, so we copy `memory_usage.index`.
+    memory_usage.index = memory_usage.index.copy()
     memory_usage.index.name = "Column Name"
     return memory_usage
 

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -33,10 +33,7 @@ def test_get_name(path, name):
     assert dataset_report.get_name(path) == name
 
 
-@pytest.mark.xfail(
-    reason="The argument and the return value share an index instance",
-    strict=True,
-)
 def test_get_memory_usage(dataframe):
+    # Test that the argument and the return value do not share an index instance.
     memory_usage = dataset_report.get_memory_usage(dataframe)
     assert dataframe.columns is not memory_usage.index

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -1,8 +1,22 @@
 import pathlib
 
+import pandas
 import pytest
 
 from analysis import dataset_report
+
+
+@pytest.fixture
+def dataframe():
+    return pandas.DataFrame(
+        {
+            "patient_id": [1],
+            "is_registered": [True],
+            "is_dead": [False],
+            "stp_code": ["STP0"],
+            "has_sbp_event": [True],
+        }
+    )
 
 
 @pytest.mark.parametrize(
@@ -17,3 +31,12 @@ from analysis import dataset_report
 )
 def test_get_name(path, name):
     assert dataset_report.get_name(path) == name
+
+
+@pytest.mark.xfail(
+    reason="The argument and the return value share an index instance",
+    strict=True,
+)
+def test_get_memory_usage(dataframe):
+    memory_usage = dataset_report.get_memory_usage(dataframe)
+    assert dataframe.columns is not memory_usage.index


### PR DESCRIPTION
The argument and the return value should not share an index instance.