### PR TITLE
Include data types in summary

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -19,8 +19,8 @@ def finalize(value):
 
 
 @finalize.register
-def _(value: pandas.Series):
-    return value.to_frame().to_html()
+def _(value: pandas.DataFrame):
+    return value.to_html()
 
 
 ENVIRONMENT = jinja2.Environment(
@@ -74,8 +74,15 @@ def get_data_types(dataframe):
     return dtypes
 
 
-def get_dataset_report(input_file, memory_usage):
-    return TEMPLATE.render(input_file=input_file, memory_usage=memory_usage)
+def get_summary(dataframe):
+    memory_usage = get_memory_usage(dataframe)
+    data_types = get_data_types(dataframe)
+    summary = memory_usage.to_frame().join(data_types)
+    return summary
+
+
+def get_dataset_report(input_file, summary):
+    return TEMPLATE.render(input_file=input_file, summary=summary)
 
 
 def write_dataset_report(output_file, dataset_report):
@@ -90,10 +97,10 @@ def main():
 
     for input_file in input_files:
         input_dataframe = read_dataframe(input_file)
-        memory_usage = get_memory_usage(input_dataframe)
+        summary = get_summary(input_dataframe)
 
         output_file = output_dir / f"{get_name(input_file)}.html"
-        dataset_report = get_dataset_report(input_file, memory_usage)
+        dataset_report = get_dataset_report(input_file, summary)
         write_dataset_report(output_file, dataset_report)
 
 

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -66,6 +66,14 @@ def get_memory_usage(dataframe):
     return memory_usage
 
 
+def get_data_types(dataframe):
+    dtypes = dataframe.dtypes
+    dtypes.name = "Data Type"
+    dtypes.index = dtypes.index.copy()
+    dtypes.index.name = "Column Name"
+    return dtypes
+
+
 def get_dataset_report(input_file, memory_usage):
     return TEMPLATE.render(input_file=input_file, memory_usage=memory_usage)
 

--- a/analysis/templates/dataset_report.html
+++ b/analysis/templates/dataset_report.html
@@ -11,8 +11,8 @@
     <article>
         <h1>Dataset Report</h1>
         <p><em>{{ input_file }}</em></p>
-        <h2>Memory Usage</h2>
-        {{ memory_usage }}
+        <h2>Summary</h2>
+        {{ summary }}
     </article>
 </body>
 

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -33,7 +33,14 @@ def test_get_name(path, name):
     assert dataset_report.get_name(path) == name
 
 
-def test_get_memory_usage(dataframe):
+@pytest.mark.parametrize(
+    "summary_function",
+    [
+        dataset_report.get_memory_usage,
+        dataset_report.get_data_types,
+    ],
+)
+def test_summary_function(summary_function, dataframe):
     # Test that the argument and the return value do not share an index instance.
-    memory_usage = dataset_report.get_memory_usage(dataframe)
-    assert dataframe.columns is not memory_usage.index
+    summary = summary_function(dataframe)
+    assert dataframe.columns is not summary.index


### PR DESCRIPTION
To do this, we create a new function that will return a summary. As before, the aim is to keep the `main` function as simple as possible.

We also parameterize the test function, such that it can now be applied to two summary functions. Stepping through the commits one-by-one might help, when reviewing this PR.