### PR TITLE
Summarise boolean columns

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -81,6 +81,16 @@ def get_summary(dataframe):
     return summary
 
 
+def is_boolean(series):
+    """Does series contain boolean values?
+
+    Because series may have been read from an untyped file, such as a csv file, it may
+    contain boolean values but may not have a boolean data type.
+    """
+    series = series.dropna()
+    return ((series == 0) | (series == 1)).all()
+
+
 def get_dataset_report(input_file, summary):
     return TEMPLATE.render(input_file=input_file, summary=summary)
 

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -91,8 +91,23 @@ def is_boolean(series):
     return ((series == 0) | (series == 1)).all()
 
 
-def get_dataset_report(input_file, summary):
-    return TEMPLATE.render(input_file=input_file, summary=summary)
+def get_column_summaries(dataframe):
+    for name, series in dataframe.items():
+        if name == "patient_id":
+            continue
+
+        if is_boolean(series):
+            count = series.value_counts()
+            percentage = count / count.sum() * 100
+            summary = pandas.DataFrame({"Count": count, "Percentage": percentage})
+            summary.index.name = "Column Value"
+            yield name, summary
+
+
+def get_dataset_report(input_file, summary, column_summaries):
+    return TEMPLATE.render(
+        input_file=input_file, summary=summary, column_summaries=column_summaries
+    )
 
 
 def write_dataset_report(output_file, dataset_report):
@@ -108,9 +123,10 @@ def main():
     for input_file in input_files:
         input_dataframe = read_dataframe(input_file)
         summary = get_summary(input_dataframe)
+        column_summaries = get_column_summaries(input_dataframe)
 
         output_file = output_dir / f"{get_name(input_file)}.html"
-        dataset_report = get_dataset_report(input_file, summary)
+        dataset_report = get_dataset_report(input_file, summary, column_summaries)
         write_dataset_report(output_file, dataset_report)
 
 

--- a/analysis/templates/dataset_report.html
+++ b/analysis/templates/dataset_report.html
@@ -13,6 +13,12 @@
         <p><em>{{ input_file }}</em></p>
         <h2>Summary</h2>
         {{ summary }}
+        <h2>Columns</h2>
+        <p>Only columns that dataset-report can summarize are shown.</p>
+        {% for column_name, column_summary in column_summaries %}
+        <h3>{{ column_name }}</h3>
+        <p>{{ column_summary }}</p>
+        {% endfor %}
     </article>
 </body>
 

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -1,5 +1,7 @@
+import datetime
 import pathlib
 
+import numpy
 import pandas
 import pytest
 
@@ -44,3 +46,26 @@ def test_summary_function(summary_function, dataframe):
     # Test that the argument and the return value do not share an index instance.
     summary = summary_function(dataframe)
     assert dataframe.columns is not summary.index
+
+
+class TestIsBool:
+    def test_with_boolean(self):
+        assert dataset_report.is_boolean(pandas.Series([0, 1], dtype=int))
+        assert dataset_report.is_boolean(pandas.Series([0, 1], dtype=float))
+        assert dataset_report.is_boolean(pandas.Series([numpy.nan, 1], dtype=float))
+        assert dataset_report.is_boolean(pandas.Series([False, True], dtype=bool))
+
+    def test_with_non_boolean(self):
+        assert not dataset_report.is_boolean(pandas.Series([0, 2], dtype=int))
+        assert not dataset_report.is_boolean(pandas.Series([0.1, 0.2], dtype=float))
+        assert not dataset_report.is_boolean(pandas.Series([numpy.nan, 2], dtype=float))
+        assert not dataset_report.is_boolean(pandas.Series(["0", "1"], dtype=str))
+        assert not dataset_report.is_boolean(
+            pandas.Series(
+                [
+                    datetime.datetime(2022, 1, 1),
+                    datetime.datetime(2022, 1, 2),
+                ],
+                dtype="datetime64[ns]",
+            )
+        )


### PR DESCRIPTION
With this PR, a dataset report now includes counts and percentages of values for boolean columns. For example:

![Screenshot 2022-05-13 at 11-42-48 Dataset Report](https://user-images.githubusercontent.com/477263/168267748-79a55916-eb33-4561-9115-f0fa4ad48b09.png)

