### PR TITLE
Report more missing values

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -92,7 +92,7 @@ def get_column_summaries(dataframe):
             continue
 
         if is_boolean(series):
-            count = series.value_counts()
+            count = series.value_counts(dropna=False)
             percentage = count / count.sum() * 100
             summary = pandas.DataFrame({"Count": count, "Percentage": percentage})
             summary.index.name = "Column Value"

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -53,6 +53,30 @@ def test_get_table_summary():
     testing.assert_frame_equal(obs_table_summary, exp_table_summary)
 
 
+def test_get_column_summaries():
+    # arrange
+    dataframe = pandas.DataFrame(
+        {
+            "patient_id": pandas.Series([1, 2, 3, 4], dtype=int),
+            "is_registered": pandas.Series([1, 0, numpy.nan, numpy.nan], dtype=float),
+        },
+    )
+    # act
+    obs_column_summaries = list(dataset_report.get_column_summaries(dataframe))
+    # assert
+    assert len(obs_column_summaries) == 1
+    obs_name, obs_summary = obs_column_summaries[0]
+    assert obs_name == "is_registered"
+    exp_index = pandas.Index([numpy.nan, 0, 1], dtype=float, name="Column Value")
+    exp_summary = pandas.DataFrame(
+        {
+            "Count": pandas.Series([2, 1, 1], index=exp_index, dtype=int),
+            "Percentage": pandas.Series([50, 25, 25], index=exp_index, dtype=float),
+        }
+    )
+    testing.assert_frame_equal(obs_summary, exp_summary)
+
+
 class TestIsBoolean:
     @pytest.mark.parametrize(
         "data,dtype",


### PR DESCRIPTION
This reports missing values per-column, for boolean columns. Having implemented (and tested) it, I realised that cohort-extractor returns missing values in boolean columns as zeros, making it redundant. Nevertheless, the test shows what *should* happen.

On a lighter note, we will probably use the code that reports missing values in boolean columns for other nominal/ordinal columns, such as string (object) columns and category columns. So, it won't always be redundant!

Fixes #15