### PR TITLE
Automated redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 dataset-report generates a report for each dataset in an input directory.
 _Datasets_ are extracted by [cohort-extractor][].
 
+## Disclosure controls
+
+dataset-report applies disclosure controls to each report that it generates,
+meaning OpenSAFELY output checkers can be confident that a report is a safe output.
+Specifically, dataset-report:
+
+* rounds counts to the nearest five; then
+* redacts counts that are less than or equal to five.
+
+The OpenSAFELY documentation has more information on [disclosure controls and safe outputs][2].
+
 ## Usage
 
 In summary:
@@ -44,4 +55,5 @@ generate_dataset_report:
 Please see [_DEVELOPERS.md_](DEVELOPERS.md).
 
 [1]: https://github.com/opensafely-actions/dataset-report/tags
+[2]: https://docs.opensafely.org/releasing-files/
 [cohort-extractor]: https://docs.opensafely.org/actions-cohortextractor/

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -78,7 +78,7 @@ def get_table_summary(dataframe):
 
 
 def is_boolean(series):
-    """Does series contain boolean values?
+    """Does series contain only boolean values?
 
     Because series may have been read from an untyped file, such as a csv file, it may
     contain boolean values but may not have a boolean data type.

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -86,13 +86,17 @@ def is_boolean(series):
     return ((series == 0) | (series == 1)).all()
 
 
+def count_values(series):
+    return series.value_counts(dropna=False)
+
+
 def get_column_summaries(dataframe):
     for name, series in dataframe.items():
         if name == "patient_id":
             continue
 
         if is_boolean(series):
-            count = series.value_counts(dropna=False)
+            count = count_values(series)
             percentage = count / count.sum() * 100
             summary = pandas.DataFrame({"Count": count, "Percentage": percentage})
             summary.index.name = "Column Value"

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -60,17 +60,19 @@ def read_dataframe(path):
     return dataframe
 
 
+def is_empty(series):
+    """Does series contain only missing values?"""
+    return series.isna().all()
+
+
 def get_table_summary(dataframe):
     memory_usage = dataframe.memory_usage(index=False)
     memory_usage = memory_usage / 1_000**2
-    count_na = len(dataframe) - dataframe.count()
-    percentage_na = count_na / len(dataframe) * 100
     return pandas.DataFrame(
         {
             "Size (MB)": memory_usage,
             "Data Type": dataframe.dtypes,
-            "Count of missing values": count_na,
-            "Percentage of missing values": percentage_na,
+            "Empty": dataframe.apply(is_empty),
         },
     )
 

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -53,6 +53,16 @@ def test_get_table_summary():
     testing.assert_frame_equal(obs_table_summary, exp_table_summary)
 
 
+def test_count_values():
+    # arrange
+    series = pandas.Series([1, 0, numpy.nan, numpy.nan], dtype=float)
+    # act
+    obs_count = dataset_report.count_values(series)
+    # assert
+    exp_count = pandas.Series([2, 1, 1], index=[numpy.nan, 0, 1], dtype=int)
+    testing.assert_series_equal(obs_count, exp_count)
+
+
 def test_get_column_summaries():
     # arrange
     dataframe = pandas.DataFrame(

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -55,11 +55,18 @@ def test_get_table_summary():
 
 def test_count_values():
     # arrange
-    series = pandas.Series([1, 0, numpy.nan, numpy.nan], dtype=float)
+    # value of 0:   there are 5, not rounded, suppressed
+    # value of 1:   there are 6, rounded down to 5, suppressed
+    # value of nan: there are 8, rounded up to 10, not suppressed
+    series = pandas.Series([0] * 5 + [1] * 6 + [numpy.nan] * 8, dtype=float)
     # act
-    obs_count = dataset_report.count_values(series)
+    obs_count = dataset_report.count_values(series, base=5, threshold=5)
     # assert
-    exp_count = pandas.Series([2, 1, 1], index=[numpy.nan, 0, 1], dtype=int)
+    exp_count = pandas.Series(
+        [10, numpy.nan, numpy.nan],
+        index=[numpy.nan, 0, 1],  # value of nan should be sorted first
+        dtype=float,
+    )
     testing.assert_series_equal(obs_count, exp_count)
 
 
@@ -67,8 +74,9 @@ def test_get_column_summaries():
     # arrange
     dataframe = pandas.DataFrame(
         {
-            "patient_id": pandas.Series([1, 2, 3, 4], dtype=int),
-            "is_registered": pandas.Series([1, 0, numpy.nan, numpy.nan], dtype=float),
+            # won't be suppressed
+            "patient_id": pandas.Series(range(8), dtype=int),
+            "is_registered": pandas.Series([1] * 8, dtype=int),
         },
     )
     # act
@@ -77,11 +85,12 @@ def test_get_column_summaries():
     assert len(obs_column_summaries) == 1
     obs_name, obs_summary = obs_column_summaries[0]
     assert obs_name == "is_registered"
-    exp_index = pandas.Index([numpy.nan, 0, 1], dtype=float, name="Column Value")
+    exp_index = pandas.Index([1], dtype=int, name="Column Value")
     exp_summary = pandas.DataFrame(
         {
-            "Count": pandas.Series([2, 1, 1], index=exp_index, dtype=int),
-            "Percentage": pandas.Series([50, 25, 25], index=exp_index, dtype=float),
+            # will be rounded
+            "Count": pandas.Series([10], index=exp_index, dtype=int),
+            "Percentage": pandas.Series([100], index=exp_index, dtype=float),
         }
     )
     testing.assert_frame_equal(obs_summary, exp_summary)

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -23,34 +23,20 @@ def test_get_name(path, name):
     assert dataset_report.get_name(path) == name
 
 
-def test_get_table_summary():
-    # arrange
-    dataframe = pandas.DataFrame(
-        {
-            "patient_id": pandas.Series([1, 2, 3, 4], dtype=int),
-            "is_registered": pandas.Series([1, 0, numpy.nan, numpy.nan], dtype=float),
-        },
+class TestIsEmpty:
+    def test_with_empty_series(self):
+        series = pandas.Series([numpy.nan, numpy.nan, numpy.nan], dtype=float)
+        assert dataset_report.is_empty(series)
+
+    @pytest.mark.parametrize(
+        "series",
+        [
+            pandas.Series([0, 1, 1], dtype=int),
+            pandas.Series([0, 1, numpy.nan], dtype=float),
+        ],
     )
-    # act
-    obs_table_summary = dataset_report.get_table_summary(dataframe)
-    # assert
-    del obs_table_summary["Size (MB)"]  # don't test
-    del obs_table_summary["Data Type"]  # don't test
-    exp_table_summary = pandas.DataFrame(
-        {
-            "Count of missing values": pandas.Series(
-                [0, 2],
-                index=dataframe.columns,
-                dtype=int,
-            ),
-            "Percentage of missing values": pandas.Series(
-                [0, 50],
-                index=dataframe.columns,
-                dtype=float,
-            ),
-        }
-    )
-    testing.assert_frame_equal(obs_table_summary, exp_table_summary)
+    def test_with_non_empty_series(self, series):
+        assert not dataset_report.is_empty(series)
 
 
 def test_count_values():


### PR DESCRIPTION
## What is a dataset report?

A dataset report[^1] has two sections, each containing one or more tables. The table within the _Summary_ section facilitates comparisons **between all** columns in the dataset; each table within the _Columns_ section facilitates comparisons **within each** column in the dataset.

This PR removes the need for any redaction from the table within the _Summary_ section; and adds automated redaction to each table within the _Columns_ section.

## The _Summary_ section

Previously, the table within the summary section gave the

* Size (MB)
* Data Type
* Count of Missing Values
* Percentage of Missing Values

for each column in the dataset. Clearly, the count and percentage should be subject to automatic redaction. However, following discussion (#17) it became clear that the count and percentage were less important than whether a column was empty (i.e. a boolean flag), which need not be subject to automatic redaction. 8747a15 replaces the count and percentage with an Empty column, like this:

![Screenshot 2022-05-25 at 15-18-32 Dataset Report](https://user-images.githubusercontent.com/477263/170284364-caf6a63e-abca-42cf-a681-357e76fbc303.png)

## What is automated redaction?

Each table within the _Columns_ section gives the count and percentage of values (including missing values) within a column in the dataset, like this:

![Screenshot 2022-05-25 at 15-20-41 Dataset Report](https://user-images.githubusercontent.com/477263/170284874-d84420ee-4057-42e4-adbb-614201775f4b.png)

Within this context, automated redaction means applying these steps:

1. suppressing counts less than a `threshold` value of `5`; these counts are replaced with missing values
2. rounding counts to a `base` value of `5`

aedf6a1 applies these steps in this order (suppressing is first; rounding is second). Eventually, the values of `threshold` and `base` could be configured by the user. However, following a discussion with @LFISHER7, `5` and `5` seemed like the most common choice in use at present, with `7` and `5` as the second most common choice. Percentages are calculated from counts.

## Next steps

This PR isn't the last word on automated redaction and dataset-report.[^1] Nevertheless, it adds some automated redaction functionality in step with some reporting functionality. Possible next steps include:

* allowing the user to specify the values of `threshold` and `base`
* allowing the user to specify the nature, and order, of the steps (suppress then round; round then suppress; just suppress; just round)
* suppressing with a value other than the missing value (`numpy.nan`)
* redacting (removing) suppressed values

[^1]: _dataset-report_ is the reusable action; _a dataset report_ is the result of applying the reusable action to a dataset. Pedantry!