### PR TITLE
Add an example report

### DIFF
--- a/docs/input.html
+++ b/docs/input.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Dataset Report</title>
+</head>
+
+<body>
+    <article>
+        <h1>Dataset Report</h1>
+        <p><em>output/input.csv</em></p>
+        <h2>Summary</h2>
+        <table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>Size (MB)</th>
+      <th>Data Type</th>
+      <th>Empty</th>
+    </tr>
+    <tr>
+      <th>Column Name</th>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>is_registered</th>
+      <td>0.008</td>
+      <td>int64</td>
+      <td>False</td>
+    </tr>
+    <tr>
+      <th>is_dead</th>
+      <td>0.008</td>
+      <td>int64</td>
+      <td>False</td>
+    </tr>
+    <tr>
+      <th>stp_code</th>
+      <td>0.008</td>
+      <td>object</td>
+      <td>False</td>
+    </tr>
+    <tr>
+      <th>has_sbp_event</th>
+      <td>0.008</td>
+      <td>int64</td>
+      <td>False</td>
+    </tr>
+    <tr>
+      <th>patient_id</th>
+      <td>0.008</td>
+      <td>int64</td>
+      <td>False</td>
+    </tr>
+  </tbody>
+</table>
+        <h2>Columns</h2>
+        <p>Only columns that dataset-report can summarize are shown.</p>
+
+        <h3>is_registered</h3>
+        <p><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>Count</th>
+      <th>Percentage</th>
+    </tr>
+    <tr>
+      <th>Column Value</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>1</th>
+      <td>1000</td>
+      <td>100.0</td>
+    </tr>
+  </tbody>
+</table></p>
+
+        <h3>is_dead</h3>
+        <p><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>Count</th>
+      <th>Percentage</th>
+    </tr>
+    <tr>
+      <th>Column Value</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>900</td>
+      <td>90.0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>100</td>
+      <td>10.0</td>
+    </tr>
+  </tbody>
+</table></p>
+
+        <h3>has_sbp_event</h3>
+        <p><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>Count</th>
+      <th>Percentage</th>
+    </tr>
+    <tr>
+      <th>Column Value</th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>900</td>
+      <td>90.0</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>100</td>
+      <td>10.0</td>
+    </tr>
+  </tbody>
+</table></p>
+
+    </article>
+</body>
+
+</html>


### PR DESCRIPTION
This adds an example report to the repo. If we link to it from README.me, then it won't render as HTML. So, I'm hoping to publish it [using GitHub pages](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site). However, it needs to exist first 🙂 