### PR TITLE
Handle boolean values encoded as `int`s for CSV files only

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -127,7 +127,9 @@ def get_column_summaries(dataframe):
         if name == "patient_id":
             continue
 
-        if is_bool_as_int(series) or types.is_bool_dtype(series):
+        is_csv_bool = dataframe.attrs["from_csv"] and is_bool_as_int(series)
+        is_bool = types.is_bool_dtype(series)
+        if is_csv_bool or is_bool:
             count = count_values(series, threshold=5, base=5)
             percentage = count / count.sum() * 100
             summary = pandas.DataFrame({"Count": count, "Percentage": percentage})

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -104,8 +104,15 @@ def test_count_values():
     testing.assert_series_equal(obs_count, exp_count)
 
 
-@pytest.mark.parametrize("dtype,num_column_summaries", [(int, 1), (bool, 1)])
-def test_get_column_summaries(dtype, num_column_summaries):
+@pytest.mark.parametrize(
+    "from_csv,dtype,num_column_summaries",
+    [
+        (True, int, 1),  # bool-as-int
+        (False, bool, 1),  # bool-as-bool
+        (False, int, 0),  # int
+    ],
+)
+def test_get_column_summaries(from_csv, dtype, num_column_summaries):
     # arrange
     dataframe = pandas.DataFrame(
         {
@@ -114,6 +121,7 @@ def test_get_column_summaries(dtype, num_column_summaries):
             "is_registered": pandas.Series([1] * 8, dtype=dtype),
         },
     )
+    dataframe.attrs["from_csv"] = from_csv
     # act
     obs_column_summaries = list(dataset_report.get_column_summaries(dataframe))
     # assert


### PR DESCRIPTION
cohort-extractor encodes boolean values as `int`s when exporting CSV files, but encodes boolean values as `bool`s when exporting non-CSV files, such as feather files.

Previously, when dataset-report encountered an `int` column that contained only values of `0`, `1`, or `numpy.nan`, then it considered this column to contain boolean values encoded as `int`s. When discussing #22, however, @wjchulme pointed out that handling boolean values encoded as `int`s for all file types could confuse researchers who had exported non-CSV files. For example, if a researcher exported a non-CSV file that contained a count column and there were counts of only `0` or `1`,[^1] then dataset-report would consider this column to contain boolean values encoded as `int`s and would compute unhelpful summary statistics.

Ultimately, we want to encourage researchers to export non-CSV files, so distinguishing between CSV and non-CSV file types, and computing helpful summary statistics for each, is worthwhile.

[^1]: Their study definition could include `patients.with_these_clinical_events(returning="number_of_matches_in_period", ...)`, for example.