### PR TITLE
Produce a summary table for each boolean data type

### DIFF
--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -92,6 +92,15 @@ def is_bool_as_int(series):
         return False
 
 
+def select(dataframe, func):
+    """Returns a subset of dataframe's columns, based on func.
+
+    func is a filter: if it returns True, then the column is included; if it returns
+    False, then the column is excluded.
+    """
+    return dataframe.loc[:, [k for k, v in dataframe.items() if func(v)]]
+
+
 def round_to_nearest(series, base):
     """Rounds values in series to the nearest base."""
     # ndigits=0 ensures the return value is a whole number, but with the same type as x

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -110,13 +110,17 @@ def suppress(series, threshold):
     return series_copy
 
 
+def _count_values_from_internal_domain(series):
+    return series.value_counts(dropna=False)
+
+
 def count_values(series, *, base, threshold):
     """Counts values, including missing values, in series.
 
     Rounds counts to the nearest base; then suppresses counts less than or equal to
     threshold.
     """
-    count = series.value_counts(dropna=False)
+    count = _count_values_from_internal_domain(series)
     count = count.pipe(round_to_nearest, base).pipe(suppress, threshold)
     count = count.sort_index(na_position="first")
     return count

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -114,13 +114,23 @@ def _count_values_from_internal_domain(series):
     return series.value_counts(dropna=False)
 
 
-def count_values(series, *, base, threshold):
-    """Counts values, including missing values, in series.
+def _count_values_from_external_domain(series, domain):
+    return pandas.Series({x: sum(series == x) for x in domain}, name=series.name)
+
+
+def count_values(series, domain=None, *, base, threshold):
+    """Counts values in series.
+
+    By default, counts values, including missing values, in series from the internal
+    domain of series. Otherwise, counts values in series from the external domain.
 
     Rounds counts to the nearest base; then suppresses counts less than or equal to
     threshold.
     """
-    count = _count_values_from_internal_domain(series)
+    if domain is None:
+        count = _count_values_from_internal_domain(series)
+    else:
+        count = _count_values_from_external_domain(series, domain)
     count = count.pipe(round_to_nearest, base).pipe(suppress, threshold)
     count = count.sort_index(na_position="first")
     return count

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -118,7 +118,7 @@ def _count_values_from_external_domain(series, domain):
     return pandas.Series({x: sum(series == x) for x in domain}, name=series.name)
 
 
-def count_values(series, domain=None, *, base, threshold):
+def count_values(series, domain=None, normalize=False, *, base, threshold):
     """Counts values in series.
 
     By default, counts values, including missing values, in series from the internal
@@ -132,6 +132,8 @@ def count_values(series, domain=None, *, base, threshold):
     else:
         count = _count_values_from_external_domain(series, domain)
     count = count.pipe(round_to_nearest, base).pipe(suppress, threshold)
+    if normalize:
+        count = count / count.sum() * 100
     count = count.sort_index(na_position="first")
     return count
 

--- a/analysis/dataset_report.py
+++ b/analysis/dataset_report.py
@@ -131,6 +131,7 @@ def count_values(series, domain=None, normalize=False, *, base, threshold):
         count = _count_values_from_internal_domain(series)
     else:
         count = _count_values_from_external_domain(series, domain)
+    count.index.name = "Column Value"
     count = count.pipe(round_to_nearest, base).pipe(suppress, threshold)
     if normalize:
         count = count / count.sum() * 100

--- a/analysis/templates/dataset_report.html
+++ b/analysis/templates/dataset_report.html
@@ -18,12 +18,12 @@
         <p><em>{{ input_file }}</em></p>
         <h2>Summary</h2>
         {{ table_summary }}
-        <h2>Columns</h2>
+        <h2>Data Types</h2>
         <p>Only columns that dataset-report can summarize are shown.</p>
-        {% for column_name, column_summary in column_summaries %}
+        {% for dtype_name, dtype_summary in dtype_summaries %}
         <section>
-            <h3>{{ column_name }}</h3>
-            {{ column_summary }}
+            <h3>{{ dtype_name }}</h3>
+            {{ dtype_summary }}
         </section>
         {% endfor %}
     </article>

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -98,7 +98,8 @@ def test_count_values():
     # assert
     exp_count = pandas.Series(
         [10, numpy.nan, numpy.nan],
-        index=[numpy.nan, 0, 1],  # value of nan should be sorted first
+        # value of nan should be sorted first
+        index=pandas.Index([numpy.nan, 0, 1], name="Column Value"),
         dtype=float,
     )
     testing.assert_series_equal(obs_count, exp_count)

--- a/tests/test_dataset_report.py
+++ b/tests/test_dataset_report.py
@@ -105,30 +105,6 @@ def test_count_values():
     testing.assert_series_equal(obs_count, exp_count)
 
 
-@pytest.mark.parametrize(
-    "from_csv,dtype,num_column_summaries",
-    [
-        (True, int, 1),  # bool-as-int
-        (False, bool, 1),  # bool-as-bool
-        (False, int, 0),  # int
-    ],
-)
-def test_get_column_summaries(from_csv, dtype, num_column_summaries):
-    # arrange
-    dataframe = pandas.DataFrame(
-        {
-            # won't be suppressed
-            "patient_id": pandas.Series(range(8), dtype=int),
-            "is_registered": pandas.Series([1] * 8, dtype=dtype),
-        },
-    )
-    dataframe.attrs["from_csv"] = from_csv
-    # act
-    obs_column_summaries = list(dataset_report.get_column_summaries(dataframe))
-    # assert
-    assert len(obs_column_summaries) == num_column_summaries
-
-
 class TestIsBoolAsInt:
     @pytest.mark.parametrize(
         "data,dtype",


### PR DESCRIPTION
This pull request produces a summary table for bool-as-int and bool-as-bool data types (#29). Each summary table has one row for each column in the underlying dataset and columns for counts and percentages of values. For example:

![Screenshot 2022-06-20 at 18-18-35 Dataset Report](https://user-images.githubusercontent.com/477263/174651807-bcc64f71-c15e-48af-b943-103cd779dc0f.png)

And:

![Screenshot 2022-06-20 at 18-19-11 Dataset Report](https://user-images.githubusercontent.com/477263/174651876-a834c5ba-ac5c-4bad-9b6d-09afca8c306b.png)

I have reservations 😬. This pull request introduces a lot of extra code for what should be a simple operation: computing counts and percentages. dataset-report produced counts and percentages before this pull-request ([example](https://opensafely-actions.github.io/dataset-report/input.html)), so what you see here is, I think, the minimum amount of code needed to reshape them from one-table-per-column to one-table-per-data type.

Infuriatingly, the extra code **doesn't represent the precision of the values in the underlying table correctly** (e.g. `0` rather than `0.0`) and **doesn't scale** to other countable columns, such as categorical columns.

I think the most important question when reviewing this pull request is: "To what extent is it important for a researcher to make comparisons _between_ columns that have boolean data types?" Possible answers, and their consequences:

* Not very much ➡️ We don't need this pull request
* Somewhat ➡️ We might need this pull request, but we might instead need better navigation within each report (e.g. a TOC and "Back to top" links)
* Very much ➡️ We need this pull request

I'd appreciate your thoughts, @wjchulme, @robinyjpark, and @Jongmassey.

Closes #22