### PR TITLE
Run status checks on pull request to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,10 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-
-concurrency: tag-new-version-group
+  workflow_call:
 
 jobs:
   check:
@@ -46,14 +45,3 @@ jobs:
       - uses: actions/checkout@v2
       - uses: opensafely-core/research-action@v2
 
-  tag-new-version:
-    needs: [test-integration]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Tag new version
-        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          create_annotated_tag: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,28 @@
+---
+name: Tag new version
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency: tag-new-version-group
+
+jobs:
+  ci:
+    uses: ./.github/workflows/main.yml
+
+  tag-new-version:
+    needs: [ci]
+    runs-on: ubuntu-latest
+
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag new version
+        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true


### PR DESCRIPTION
With the introduction of a branch protection ruleset (https://github.com/opensafely-actions/.github/issues/9), we should run status checks on pull requests that target the `main` branch, and block merging before they pass.

Note that I have "borrowed" the `tag.yml` format from a similar repo, [deciles-charts](https://github.com/opensafely-actions/deciles-charts/blob/main/.github/workflows/tag.yml). 